### PR TITLE
Update/zod utils

### DIFF
--- a/lib/shared/validation/utils/zodUtils.ts
+++ b/lib/shared/validation/utils/zodUtils.ts
@@ -39,7 +39,7 @@ export class ZodUtils {
    * // }
    */
   static getZodDefaults<ZodSchema extends z.AnyZodObject, Schema = z.TypeOf<ZodSchema>>(
-    zodSchema: ZodSchema | z.ZodEffects<ZodSchema> | z.ZodIntersection<ZodSchema, ZodSchema>,
+    zodSchema: ZodSchema | z.ZodEffects<ZodSchema>,
     options?: ZodUtilsGetDefaultsOptions
   ): Schema {
     const { fillArrayWithValue } = options || {}
@@ -63,7 +63,7 @@ export class ZodUtils {
         case schema._def.typeName === 'ZodArray' || schema instanceof z.ZodArray:
           return fillArrayWithValue ? [getDefaultValue((schema as z.ZodArray<ZodSchema>).element)] : []
         case schema._def.typeName === 'ZodObject' || schema instanceof z.ZodObject:
-          return this.getZodDefaults(schema, options)
+          return this.getZodDefaults(schema as z.ZodObject<z.ZodRawShape>, options)
         case schema._def.typeName === 'ZodUnion' || schema instanceof z.ZodUnion:
           return getDefaultValue(schema._def.options[0])
         case schema._def.typeName === 'ZodLiteral' || schema instanceof z.ZodLiteral:
@@ -87,9 +87,7 @@ export class ZodUtils {
 
     const defaults = {} as Schema
 
-    const schemaShape = zodSchema instanceof z.ZodIntersection ? this.zodMergeIntersection(zodSchema).shape : zodSchema.shape
-
-    const schemaEntries = Object.entries(schemaShape) as [keyof Schema, z.ZodAny][]
+    const schemaEntries = Object.entries(zodSchema.shape) as [keyof Schema, z.ZodAny][]
 
     schemaEntries.map(([key, value]) => {
       defaults[key] = getDefaultValue(value) as Schema[keyof Schema]

--- a/lib/shared/validation/utils/zodUtils.ts
+++ b/lib/shared/validation/utils/zodUtils.ts
@@ -54,29 +54,29 @@ export class ZodUtils {
 
     const getDefaultValue = (schema: z.ZodTypeAny): unknown => {
       switch (true) {
-        case schema instanceof z.ZodDefault:
-          return schema._def.defaultValue()
-        case schema instanceof z.ZodOptional:
+        case schema._def.typeName === 'ZodDefault' || schema instanceof z.ZodDefault:
+          return (schema as z.ZodDefault<ZodSchema>)._def.defaultValue()
+        case schema._def.typeName === 'ZodOptional' || schema instanceof z.ZodOptional:
           return undefined
-        case schema instanceof z.ZodNullable:
+        case schema._def.typeName === 'ZodNullable' || schema instanceof z.ZodNullable:
           return null
-        case schema instanceof z.ZodArray:
-          return fillArrayWithValue ? [getDefaultValue(schema.element)] : []
-        case schema instanceof z.ZodObject:
+        case schema._def.typeName === 'ZodArray' || schema instanceof z.ZodArray:
+          return fillArrayWithValue ? [getDefaultValue((schema as z.ZodArray<ZodSchema>).element)] : []
+        case schema._def.typeName === 'ZodObject' || schema instanceof z.ZodObject:
           return this.getZodDefaults(schema, options)
-        case schema instanceof z.ZodUnion:
+        case schema._def.typeName === 'ZodUnion' || schema instanceof z.ZodUnion:
           return getDefaultValue(schema._def.options[0])
-        case schema instanceof z.ZodLiteral:
+        case schema._def.typeName === 'ZodLiteral' || schema instanceof z.ZodLiteral:
           return schema._def.value
-        case schema instanceof z.ZodDiscriminatedUnion:
+        case schema._def.typeName === 'ZodDiscriminatedUnion' || schema instanceof z.ZodDiscriminatedUnion:
           return getDefaultValue(schema._def.options[0])
-        case schema instanceof z.ZodEnum:
+        case schema._def.typeName === 'ZodEnum' || schema instanceof z.ZodEnum:
           return schema._def.values[0]
-        case schema instanceof z.ZodString:
+        case schema._def.typeName === 'ZodString' || schema instanceof z.ZodString:
           return ''
-        case schema instanceof z.ZodNumber:
+        case schema._def.typeName === 'ZodNumber' || schema instanceof z.ZodNumber:
           return 0
-        case schema instanceof z.ZodBoolean:
+        case schema._def.typeName === 'ZodBoolean' || schema instanceof z.ZodBoolean:
           return false
         case !('innerType' in schema._def):
           return undefined
@@ -87,8 +87,7 @@ export class ZodUtils {
 
     const defaults = {} as Schema
 
-    const schemaShape =
-      zodSchema instanceof z.ZodIntersection ? zodSchema._def.left.merge(zodSchema._def.right).shape : zodSchema.shape
+    const schemaShape = zodSchema instanceof z.ZodIntersection ? this.zodMergeIntersection(zodSchema).shape : zodSchema.shape
 
     const schemaEntries = Object.entries(schemaShape) as [keyof Schema, z.ZodAny][]
 
@@ -97,5 +96,27 @@ export class ZodUtils {
     })
 
     return defaults
+  }
+
+  /**
+   * Функция для объединения zod схождений
+   * @param {ZodIntersection} zodSchema
+   * @returns объединенная схема двух схождений
+   */
+  static zodMergeIntersection<ZodLeft extends z.ZodTypeAny, ZodRight extends z.ZodTypeAny>(
+    zodSchema: z.ZodIntersection<ZodLeft, ZodRight>
+  ): z.ZodObject<z.objectUtil.MergeShapes<z.TypeOf<ZodLeft>, z.TypeOf<ZodRight>>> {
+    const { left, right } = zodSchema._def
+
+    const leftSchema =
+      left instanceof z.ZodDiscriminatedUnion || left._def.typeName === 'ZodDiscriminatedUnion' ? left._def.options[0] : left
+    const rightSchema =
+      right instanceof z.ZodDiscriminatedUnion || left._def.typeName === 'ZodDiscriminatedUnion' ? right._def.options[0] : right
+
+    if (leftSchema instanceof z.ZodObject && rightSchema instanceof z.ZodObject) {
+      return leftSchema.merge(rightSchema)
+    }
+
+    throw new Error(`Cannot merge schema type ${rightSchema._def.typeName} to ${leftSchema._def.typeName}`)
   }
 }

--- a/lib/shared/validation/utils/zodUtils.ts
+++ b/lib/shared/validation/utils/zodUtils.ts
@@ -102,6 +102,26 @@ export class ZodUtils {
    * Функция для объединения zod схождений
    * @param {ZodIntersection} zodSchema
    * @returns объединенная схема двух схождений
+   *
+   * @example
+   * let schema = z.object({
+   *   foo: z.string()
+   * })
+   *   // this will return intersection and we need
+   *   // to merge its left to right schema's
+   *   .and(
+   *     z.object({
+   *       bar: z.string()
+   *     })
+   *   )
+   *
+   * schema = ZodUtils.zodMergeIntersection(schema)
+   *
+   * // schema will be
+   * z.object({
+   *   foo: z.string(),
+   *   bar: z.string()
+   * })
    */
   static zodMergeIntersection<ZodLeft extends z.ZodTypeAny, ZodRight extends z.ZodTypeAny>(
     zodSchema: z.ZodIntersection<ZodLeft, ZodRight>


### PR DESCRIPTION
`getZodDefaults`
- добавлена проверка типа схемы, что предотвращает проблему потери инстанса

`zodMergeIntersection`
Функция для мержа zod схождений, нужна чтобы превратить ZodIntersection, который получается при создании схемы используя:
```ts
// it will return ZodIntersection
const schema = z.object({}).and(z.object({}))
// it will be ZodObject that contains all fields in all sides in ZodIntersection
const mergedSchema = ZodUtils.zodMergeIntersection(schema)
```